### PR TITLE
HTML5 Semantics to top header search

### DIFF
--- a/blocksearch-top.tpl
+++ b/blocksearch-top.tpl
@@ -41,7 +41,7 @@
 			<input type="hidden" name="controller" value="search" />
 			<input type="hidden" name="orderby" value="position" />
 			<input type="hidden" name="orderway" value="desc" />
-			<input class="search_query" type="text" id="search_query_top" name="search_query" value="{$search_query|escape:'html':'UTF-8'|stripslashes}" />
+			<input class="search_query" type="search" id="search_query_top" name="search_query" value="{$search_query|escape:'html':'UTF-8'|stripslashes}" />
 			<input type="submit" name="submit_search" value="{l s='Search' mod='blocksearch'}" class="button" />
 		</p>
 	</form>


### PR DESCRIPTION
Line 44 for top search had a type of text when it should be 'search' for screen readers.